### PR TITLE
Prevents an NPE when using 1.7.10 if a player achievement is not valid.

### DIFF
--- a/src/com/scarsz/discordsrv/listeners/AchievementListener.java
+++ b/src/com/scarsz/discordsrv/listeners/AchievementListener.java
@@ -22,7 +22,7 @@ public class AchievementListener implements Listener {
 		// return if achievement messages are disabled
 		if (!DiscordSRV.plugin.getConfig().getBoolean("MinecraftPlayerAchievementMessagesEnabled")) return;
 		
-		if (event.getAchievement() != null || event.getPlayer() != null) {
+		if (event.getAchievement() != null && event.getPlayer() != null) {
 			DiscordSRV.sendMessage(DiscordSRV.chatChannel, ChatColor.stripColor(DiscordSRV.plugin.getConfig().getString("MinecraftPlayerAchievementMessagesFormat")
 				.replace("%username%", event.getPlayer().getName())
 				.replace("%displayname%", event.getPlayer().getDisplayName())

--- a/src/com/scarsz/discordsrv/listeners/AchievementListener.java
+++ b/src/com/scarsz/discordsrv/listeners/AchievementListener.java
@@ -22,7 +22,7 @@ public class AchievementListener implements Listener {
 		// return if achievement messages are disabled
 		if (!DiscordSRV.plugin.getConfig().getBoolean("MinecraftPlayerAchievementMessagesEnabled")) return;
 		
-		if (event.getAchievement() != null && event.getPlayer() != null) {
+		if (event.getAchievement() != null || event.getPlayer() != null) {
 			DiscordSRV.sendMessage(DiscordSRV.chatChannel, ChatColor.stripColor(DiscordSRV.plugin.getConfig().getString("MinecraftPlayerAchievementMessagesFormat")
 				.replace("%username%", event.getPlayer().getName())
 				.replace("%displayname%", event.getPlayer().getDisplayName())

--- a/src/com/scarsz/discordsrv/listeners/AchievementListener.java
+++ b/src/com/scarsz/discordsrv/listeners/AchievementListener.java
@@ -22,11 +22,13 @@ public class AchievementListener implements Listener {
 		// return if achievement messages are disabled
 		if (!DiscordSRV.plugin.getConfig().getBoolean("MinecraftPlayerAchievementMessagesEnabled")) return;
 		
-		DiscordSRV.sendMessage(DiscordSRV.chatChannel, ChatColor.stripColor(DiscordSRV.plugin.getConfig().getString("MinecraftPlayerAchievementMessagesFormat")
-			.replace("%username%", event.getPlayer().getName())
-			.replace("%displayname%", event.getPlayer().getDisplayName())
-			.replace("%world%", event.getPlayer().getWorld().getName())
-			.replace("%achievement%", event.getAchievement().toString())
-		));
+		if (event.getAchievement() != null && event.getPlayer() != null) {
+			DiscordSRV.sendMessage(DiscordSRV.chatChannel, ChatColor.stripColor(DiscordSRV.plugin.getConfig().getString("MinecraftPlayerAchievementMessagesFormat")
+				.replace("%username%", event.getPlayer().getName())
+				.replace("%displayname%", event.getPlayer().getDisplayName())
+				.replace("%world%", event.getPlayer().getWorld().getName())
+				.replace("%achievement%", event.getAchievement().toString())
+			));
+		}
 	}
 }


### PR DESCRIPTION
Should fix the following; 

```
Caused by: java.lang.NullPointerException
        at com.scarsz.discordsrv.listeners.AchievementListener.PlayerAchievementAwardedEvent(AchievementListener.java:29) ~[?:?]
        at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method) ~[?:1.8.0_66]
        at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62) ~[?:1.8.0_66]
        at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[?:1.8.0_66]
        at java.lang.reflect.Method.invoke(Method.java:497) ~[?:1.8.0_66]
        at org.bukkit.plugin.java.JavaPluginLoader$1.execute(JavaPluginLoader.java:334) ~[JavaPluginLoader$1.class:1.7.10-1614.46]
        ... 24 more
```