### PR TITLE
Resolve log4j-dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -160,10 +160,9 @@
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j</artifactId>
-            <version>1.2.12</version>
-            <scope>system</scope>
-            <systemPath>${project.basedir}/lib/minecraft_server.1.10.2.jar</systemPath>
+            <artifactId>log4j-api</artifactId>
+            <version>2.6.2</version>
+            <scope>provided</scope>
         </dependency>
     </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -164,6 +164,15 @@
             <version>2.0-beta9</version>
             <scope>provided</scope>
         </dependency>
+<!--
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+ -          <artifactId>log4j</artifactId>
+ -          <version>1.2.12</version>
+ -          <scope>system</scope>
+ -          <systemPath>${project.basedir}/lib/minecraft_server.1.10.2.jar</systemPath>
+        </dependency>
+-->
     </dependencies>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -160,7 +160,7 @@
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-api</artifactId>
+            <artifactId>log4j-core</artifactId>
             <version>2.6.2</version>
             <scope>provided</scope>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -161,7 +161,7 @@
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-core</artifactId>
-            <version>2.6.2</version>
+            <version>2.0-beta9</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
log4j-core version 2.0-beta9 was the needed version. Works fine now: [![https://jenkins.androkai.net/job/DiscordSRV-test/3/](https://jenkins.androkai.net/buildStatus/icon?job=DiscordSRV-test)](https://jenkins.androkai.net/job/DiscordSRV-test/3/)