### PR TITLE
Adding LunaChat co-operation.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -119,6 +119,10 @@
             <id>scarsz</id>
             <url>https://dl.bintray.com/scarsz/maven</url>
         </repository>
+        <repository>
+            <id>LunaChat</id>
+            <url>https://raw.github.com/ucchyocean/mvn-repo/master</url>
+        </repository>
     </repositories>
 
     <dependencies>
@@ -184,6 +188,12 @@
             <artifactId>VentureChat</artifactId>
             <version>2.9.8</version>
             <scope>provided</scope>
+        </dependency>
+        <!-- lunachat -->
+        <dependency>
+            <groupId>com.github.ucchyocean</groupId>
+            <artifactId>LunaChat</artifactId>
+            <version>2.8.6</version>
         </dependency>
 
         <!-- vault -->

--- a/src/main/java/com/scarsz/discordsrv/DiscordSRV.java
+++ b/src/main/java/com/scarsz/discordsrv/DiscordSRV.java
@@ -8,6 +8,7 @@ import com.scarsz.discordsrv.api.DiscordSRVListenerInterface;
 import com.scarsz.discordsrv.api.events.ProcessChatEvent;
 import com.scarsz.discordsrv.hooks.chat.HerochatHook;
 import com.scarsz.discordsrv.hooks.chat.LegendChatHook;
+import com.scarsz.discordsrv.hooks.chat.LunaChatHook;
 import com.scarsz.discordsrv.hooks.chat.VentureChatHook;
 import com.scarsz.discordsrv.hooks.worlds.MultiverseCoreHook;
 import com.scarsz.discordsrv.listeners.*;
@@ -72,6 +73,7 @@ public class DiscordSRV extends JavaPlugin {
     public static boolean usingHerochat = false;
     public static boolean usingLegendChat = false;
     public static boolean usingVentureChat = false;
+    public static boolean usingLunaChat = false;
 
     // account linking
     public static AccountLinkManager accountLinkManager;
@@ -246,6 +248,9 @@ public class DiscordSRV extends JavaPlugin {
         } else if (checkIfPluginEnabled("venturechat") && getConfig().getBoolean("VentureChatHook")) {
             getLogger().info("Enabling VentureChatHook hook");
             getServer().getPluginManager().registerEvents(new VentureChatHook(), this);
+        } else if (checkIfPluginEnabled("LunaChat") && getConfig().getBoolean("LunaChatHook")) {
+            getLogger().info("Enabling LunaChatHook hook");
+            getServer().getPluginManager().registerEvents(new LunaChatHook(), this);
         } else {
             getLogger().info("No chat plugin hooks enabled");
             getServer().getPluginManager().registerEvents(new ChatListener(), this);
@@ -692,7 +697,7 @@ public class DiscordSRV extends JavaPlugin {
         if (!subscribed && !unsubscribedPlayers.contains(uniqueId.toString())) unsubscribedPlayers.add(uniqueId.toString());
     }
     public static void broadcastMessageToMinecraftServer(String message, String rawMessage, String channel) {
-        boolean usingChatPlugin = usingLegendChat || usingHerochat || !channel.equalsIgnoreCase(plugin.getConfig().getString("DiscordMainChatChannel"));
+        boolean usingChatPlugin = usingLegendChat || usingHerochat || usingLunaChat || !channel.equalsIgnoreCase(plugin.getConfig().getString("DiscordMainChatChannel"));
         if (!usingChatPlugin) {
             for (Player player : Bukkit.getOnlinePlayers()) {
                 if (getIsSubscribed(player.getUniqueId())) {
@@ -704,6 +709,7 @@ public class DiscordSRV extends JavaPlugin {
             if (usingHerochat) HerochatHook.broadcastMessageToChannel(channel, message, rawMessage);
             if (usingLegendChat) LegendChatHook.broadcastMessageToChannel(channel, message, rawMessage);
             if (usingVentureChat) VentureChatHook.broadcastMessageToChannel(channel, message, rawMessage);
+            if (usingLunaChat) LunaChatHook.broadcastMessageToChannel(channel, message, rawMessage);
         }
     }
     public static String convertRoleToMinecraftColor(Role role) {

--- a/src/main/java/com/scarsz/discordsrv/hooks/chat/LunaChatHook.java
+++ b/src/main/java/com/scarsz/discordsrv/hooks/chat/LunaChatHook.java
@@ -1,0 +1,57 @@
+package com.scarsz.discordsrv.hooks.chat;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.bukkit.ChatColor;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+
+import com.github.ucchyocean.lc.LunaChat;
+import com.github.ucchyocean.lc.channel.Channel;
+import com.github.ucchyocean.lc.event.LunaChatChannelChatEvent;
+import com.scarsz.discordsrv.DiscordSRV;
+
+public class LunaChatHook implements Listener {
+
+    public LunaChatHook() {
+        DiscordSRV.usingLunaChat = true;
+    }
+
+    @EventHandler(priority = EventPriority.MONITOR)
+    public void onMessage(LunaChatChannelChatEvent event) {
+
+        // make sure chat channel is registered
+        if (!DiscordSRV.chatChannelIsLinked(event.getChannel().getName())) return;
+
+        // make sure chat channel is linked to discord channel
+        if (DiscordSRV.getTextChannelFromChannelName(event.getChannel().getName()) == null) return;
+
+        // make sure message isn't blank
+        if (event.getNgMaskedMessage().trim().isEmpty()) return;
+
+        // get sender player
+        Player player = (event.getPlayer() != null) ? event.getPlayer().getPlayer() : null;
+
+        DiscordSRV.processChatEvent(false, player, event.getNgMaskedMessage(), event.getChannel().getName());
+    }
+
+    public static void broadcastMessageToChannel(String channelName, String message, String rawMessage) {
+
+        Channel chatChannel = LunaChat.getInstance().getLunaChatAPI().getChannel(channelName);
+        if (chatChannel == null) return; // no suitable channel found
+        chatChannel.sendMessage(null, "", ChatColor.translateAlternateColorCodes('&', DiscordSRV.plugin.getConfig().getString("ChatChannelHookMessageFormat")
+                .replace("%channelcolor%", chatChannel.getColorCode())
+                .replace("%channelname%", chatChannel.getName())
+                .replace("%channelnickname%", (chatChannel.getAlias().equals("")) ? chatChannel.getName() : chatChannel.getAlias() )
+                .replace("%message%", message)), true, "Discord");
+
+        // notify players
+        List<Player> playersToNotify = new ArrayList<>();
+        chatChannel.getMembers().forEach(chatter -> playersToNotify.add(chatter.getPlayer()));
+        DiscordSRV.notifyPlayersOfMentions(playersToNotify, rawMessage);
+    }
+
+}

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -31,7 +31,7 @@ ChatChannelHookMessageFormat: "%channelcolor%[%channelnickname%]&r %message%"
 HeroChatHook: true
 LegendChatHook: true
 VentureChatHook: true
-LunaChatHook: false
+LunaChatHook: true
 
 # Game information, this sets the "Playing ______" indicator for the bot, set to "" to disable
 DiscordGameStatus: "Minecraft"

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -31,6 +31,7 @@ ChatChannelHookMessageFormat: "%channelcolor%[%channelnickname%]&r %message%"
 HeroChatHook: true
 LegendChatHook: true
 VentureChatHook: true
+LunaChatHook: false
 
 # Game information, this sets the "Playing ______" indicator for the bot, set to "" to disable
 DiscordGameStatus: "Minecraft"

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -6,7 +6,7 @@ website: https://github.com/Scarsz/DiscordSRV
 
 main: com.scarsz.discordsrv.DiscordSRV
 database: false
-softdepend: [HeroChat, Legendchat, Multiverse-Core, VentureChat, Vault]
+softdepend: [HeroChat, Legendchat, Multiverse-Core, VentureChat, LunaChat, Vault]
 load: STARTUP
 
 commands:


### PR DESCRIPTION
Regarding the following comment.
https://dev.bukkit.org/bukkit-plugins/discordsrv/#c49

Please review the source codes, and merge for DiscordSRV v12.0.
Thanks!

<s>
NOTE: Regarding the default value of "LunaChatHook" configuration, "false" is better I think.
Because, most of Japanese servers are using LunaChat only for chat coloring and IME (Kana-Kanji conversion).
A handful of people, are using the channel chat feature of LunaChat. I will announce how to connect channel chat with Discord to them.
</s>