### PR TITLE
Fix NPE while notifying LunaChat players

### DIFF
--- a/src/main/java/com/scarsz/discordsrv/hooks/chat/LunaChatHook.java
+++ b/src/main/java/com/scarsz/discordsrv/hooks/chat/LunaChatHook.java
@@ -2,6 +2,7 @@ package com.scarsz.discordsrv.hooks.chat;
 
 import com.github.ucchyocean.lc.LunaChat;
 import com.github.ucchyocean.lc.channel.Channel;
+import com.github.ucchyocean.lc.channel.ChannelPlayer;
 import com.github.ucchyocean.lc.event.LunaChatChannelChatEvent;
 import com.scarsz.discordsrv.DiscordSRV;
 import org.bukkit.ChatColor;
@@ -12,6 +13,7 @@ import org.bukkit.event.Listener;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 public class LunaChatHook implements Listener {
 
@@ -47,7 +49,7 @@ public class LunaChatHook implements Listener {
 
         // notify players
         List<Player> playersToNotify = new ArrayList<>();
-        chatChannel.getMembers().forEach(chatter -> playersToNotify.add(chatter.getPlayer()));
+        chatChannel.getMembers().stream().map(ChannelPlayer::getPlayer).filter(Objects::nonNull).forEach(chatter -> playersToNotify.add(chatter.getPlayer()));
         DiscordSRV.notifyPlayersOfMentions(playersToNotify, rawMessage);
     }
 


### PR DESCRIPTION
[com.github.ucchyocean.lc.channel.ChannelPlayer#getPlayer()](https://github.com/ucchyocean/LunaChat/blob/master/src/main/java/com/github/ucchyocean/lc/channel/ChannelPlayer.java#L62) can return null (see: [ChannelPlayerName#getPlayer()](https://github.com/ucchyocean/LunaChat/blob/master/src/main/java/com/github/ucchyocean/lc/channel/ChannelPlayerName.java#L123), [ChannelPlayerUUID#getPlayer()](https://github.com/ucchyocean/LunaChat/blob/master/src/main/java/com/github/ucchyocean/lc/channel/ChannelPlayerUUID.java#L173)). So an exception below can occur by posting a message on a discord channel connected to a Lunachat channel which has offline members.
```
[17:53:59] [ReadingThread/WARN]: [17:53:59] [Fatal] [JDA]: One of the EventListeners had an uncaught exception
[17:53:59] [ReadingThread/WARN]: [17:53:59] [Fatal] [JDA]: Encountered an exception:
[17:53:59] [ReadingThread/WARN]: [17:53:59] [Fatal] [JDA]: java.lang.NullPointerException
    at com.scarsz.discordsrv.DiscordSRV.notifyPlayersOfMentions(DiscordSRV.java:773)
    at com.scarsz.discordsrv.hooks.chat.LunaChatHook.broadcastMessageToChannel(LunaChatHook.java:51)
    at com.scarsz.discordsrv.DiscordSRV.broadcastMessageToMinecraftServer(DiscordSRV.java:728)
    at com.scarsz.discordsrv.listeners.DiscordListener.handleChat(DiscordListener.java:117)
    at com.scarsz.discordsrv.listeners.DiscordListener.onGuildMessageReceived(DiscordListener.java:52)
    at com.scarsz.discordsrv.jda.hooks.ListenerAdapter.onEvent(ListenerAdapter.java:166)
    at com.scarsz.discordsrv.jda.hooks.InterfacedEventManager.handle(InterfacedEventManager.java:64)
    at com.scarsz.discordsrv.jda.handle.MessageReceivedHandler.handleDefaultMessage(MessageReceivedHandler.java:81)
    at com.scarsz.discordsrv.jda.handle.MessageReceivedHandler.handleInternally(MessageReceivedHandler.java:50)
    at com.scarsz.discordsrv.jda.handle.SocketHandler.handle(SocketHandler.java:38)
    at com.scarsz.discordsrv.jda.requests.WebSocketClient.handleEvent(WebSocketClient.java:596)
    at com.scarsz.discordsrv.jda.requests.WebSocketClient.onTextMessage(WebSocketClient.java:324)
    at com.neovisionaries.ws.client.ListenerManager.callOnTextMessage(ListenerManager.java:352)
    at com.neovisionaries.ws.client.ReadingThread.callOnTextMessage(ReadingThread.java:233)
    at com.neovisionaries.ws.client.ReadingThread.callOnTextMessage(ReadingThread.java:211)
    at com.neovisionaries.ws.client.ReadingThread.handleTextFrame(ReadingThread.java:910)
    at com.neovisionaries.ws.client.ReadingThread.handleFrame(ReadingThread.java:693)
    at com.neovisionaries.ws.client.ReadingThread.main(ReadingThread.java:102)
    at com.neovisionaries.ws.client.ReadingThread.run(ReadingThread.java:61)
```