### PR TITLE
Strip colors in player name when using Webhook

### DIFF
--- a/src/main/java/github/scarsz/discordsrv/util/WebhookUtil.java
+++ b/src/main/java/github/scarsz/discordsrv/util/WebhookUtil.java
@@ -8,7 +8,6 @@ import net.dv8tion.jda.core.entities.Guild;
 import net.dv8tion.jda.core.entities.TextChannel;
 import net.dv8tion.jda.core.entities.Webhook;
 import org.apache.commons.lang3.exception.ExceptionUtils;
-import org.bukkit.ChatColor;
 import org.bukkit.entity.Player;
 
 public class WebhookUtil {
@@ -57,7 +56,7 @@ public class WebhookUtil {
         try {
             HttpResponse<String> response = Unirest.post(targetWebhook.getUrl())
                     .field("content", message)
-                    .field("username", ChatColor.stripColor(player.getDisplayName()))
+                    .field("username", DiscordUtil.stripColor(player.getDisplayName()))
                     .field("avatar_url", "https://minotar.net/helm/" + player.getName() + "/100.png")
                     .asString();
             DiscordSRV.debug("Received API response for webhook message delivery: " + response.getStatus());

--- a/src/main/java/github/scarsz/discordsrv/util/WebhookUtil.java
+++ b/src/main/java/github/scarsz/discordsrv/util/WebhookUtil.java
@@ -8,6 +8,7 @@ import net.dv8tion.jda.core.entities.Guild;
 import net.dv8tion.jda.core.entities.TextChannel;
 import net.dv8tion.jda.core.entities.Webhook;
 import org.apache.commons.lang3.exception.ExceptionUtils;
+import org.bukkit.ChatColor;
 import org.bukkit.entity.Player;
 
 public class WebhookUtil {
@@ -56,7 +57,7 @@ public class WebhookUtil {
         try {
             HttpResponse<String> response = Unirest.post(targetWebhook.getUrl())
                     .field("content", message)
-                    .field("username", player.getDisplayName())
+                    .field("username", ChatColor.stripColor(player.getDisplayName()))
                     .field("avatar_url", "https://minotar.net/helm/" + player.getName() + "/100.png")
                     .asString();
             DiscordSRV.debug("Received API response for webhook message delivery: " + response.getStatus());


### PR DESCRIPTION
This change prevents color codes such as "§6" appearing with the username.