### PR TITLE
ignore empty death messages

### DIFF
--- a/src/main/java/github/scarsz/discordsrv/listeners/PlayerDeathListener.java
+++ b/src/main/java/github/scarsz/discordsrv/listeners/PlayerDeathListener.java
@@ -45,6 +45,7 @@ public class PlayerDeathListener implements Listener {
         if (event.getEntityType() != EntityType.PLAYER) return;
 
         if (event.getDeathMessage() == null) return;
+        if (StringUtils.isBlank(event.getDeathMessage())) return;
 
         String discordMessage = LangUtil.Message.PLAYER_DEATH.toString()
                 .replaceAll("%time%|%date%", TimeUtil.timeStamp())


### PR DESCRIPTION
Hey!

![bug image](https://safe.tassu.me/VeNlRJccwInwlu1rc7U603l55mqCXpjB.png) 

this pr fixes a bug that sends the death message to discord even when the message is empty.

Signed-off-by: Tassu <git@tassu.me>